### PR TITLE
Fix : 장바구니 전체 선택 후 단일 해제 시 발생하는 금액 오류 해결

### DIFF
--- a/src/Cart/atoms/AllSelectButton.jsx
+++ b/src/Cart/atoms/AllSelectButton.jsx
@@ -1,15 +1,55 @@
 import React from 'react';
 import { Input } from './RadioButton';
+import { useDispatch, useSelector } from 'react-redux';
+import { setAllSelect } from '../../store/cartAllSelectSlice';
+import { notSelected } from '../../store/selectedItemSlice';
 
-export default function AllSelectButton({ btnCheck, setBtnCheck }) {
+export default function AllSelectButton() {
+	const dispatch = useDispatch();
+	const allSelect = useSelector((state) => {
+		return state.cartAllSelectSlice.value;
+	});
+
+	const totalCartPriceSlice = useSelector((state) => {
+		return state.totalCartPriceSlice.value;
+	});
+
+	const deliveryFeeSlice = useSelector((state) => {
+		return state.deliveryFeeSlice.value;
+	});
+
+	const selectedItemSlice = useSelector((state) => {
+		return state.selectedItemSlice;
+	});
+
 	return (
 		<label id="allSelect">
 			<Input
 				for="allSelect"
 				type="checkbox"
-				checked={btnCheck}
+				checked={allSelect}
 				onChange={() => {
-					setBtnCheck(!btnCheck);
+					// 단일 선택과 전체 선택의 금액 차감 액션이 겹치는 문제 발생 => 단일 선택한 아이템의 금액은 빼고 추가할 것. how?
+					// 전체 선택 -> 단일 해제시 해당 금액 notselect에 추가 -> 전체 해제 -> 이미 단일 해제에서 추가된 부분을 전체 금액에서 빼고 넣기
+					// 전체 해제 -> 단일 선택 시 해당 금액 notselect에서 빠짐 -> 전체 선택 -> 이미 단일 선택에서 빠진 부분을 넣기
+
+					if (allSelect) {
+						dispatch(
+							notSelected({
+								item: totalCartPriceSlice - selectedItemSlice.item,
+								fee: deliveryFeeSlice - selectedItemSlice.fee,
+							})
+						);
+					} else {
+						dispatch(
+							notSelected({
+								item: -selectedItemSlice.item,
+								fee: -selectedItemSlice.fee,
+							})
+						);
+					}
+
+					dispatch(setAllSelect(!allSelect));
 				}}
 			/>
 		</label>

--- a/src/Cart/atoms/RadioButton.jsx
+++ b/src/Cart/atoms/RadioButton.jsx
@@ -31,6 +31,9 @@ export const Input = styled.input`
 
 export default function RadioButton({ btnCheck, setBtnCheck, id, count, setCount }) {
 	const dispatch = useDispatch();
+	const allSelect = useSelector((state) => {
+		return state.cartAllSelectSlice.value;
+	});
 	const getFunc = useGet(`/products/${id}`);
 	const [price, setPrice] = useState();
 	const [fee, setFee] = useState();
@@ -41,6 +44,10 @@ export default function RadioButton({ btnCheck, setBtnCheck, id, count, setCount
 			setFee(res.data.shipping_fee);
 		});
 	});
+
+	useEffect(() => {
+		setBtnCheck(allSelect);
+	}, [allSelect]);
 
 	return (
 		<label id="check">

--- a/src/Cart/molecules/TitleBox.jsx
+++ b/src/Cart/molecules/TitleBox.jsx
@@ -4,21 +4,24 @@ import TitleText from '../../Common/TitleText';
 import AllSelectButton from '../atoms/AllSelectButton';
 import styled from 'styled-components';
 import AllDeleteModal from '../organisms/AllDeleteModal';
+import { useSelector } from 'react-redux';
 
-export default function TitleBox() {
-	const [btnCheck, setBtnCheck] = useState(true);
+const AllSelect = styled.button`
+	width: 70px;
+	font-size: ${(props) => props.theme.sm};
+	margin-left: 10px;
+`;
+
+export default function TitleBox(props) {
+	const allSelect = useSelector((state) => {
+		return state.cartAllSelectSlice.value;
+	});
 	const [modal, setModal] = useState(false);
-
-	const AllSelect = styled.button`
-		width: 70px;
-		font-size: ${(props) => props.theme.sm};
-		margin-left: 10px;
-	`;
 
 	return (
 		<GrayBox>
-			<AllSelectButton btnCheck={btnCheck} setBtnCheck={setBtnCheck} />
-			{btnCheck == true ? (
+			<AllSelectButton allSelect={props.allSelect} setAllSelect={props.setAllSelect} />
+			{allSelect == true ? (
 				<AllSelect
 					onClick={() => {
 						setModal(true);

--- a/src/Cart/organisms/CartItem.jsx
+++ b/src/Cart/organisms/CartItem.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import ItemBox from '../atoms/ItemBox';
 import RadioButton from '../atoms/RadioButton';
 import ItemInfo from '../molecules/ItemInfo';
@@ -8,7 +8,6 @@ import DeleteImg from '../../Common/DeleteImg';
 
 export default function CartItem({ item, index, arr, setArr, change, setChange, cartId }) {
 	const [count, setCount] = useState(item.quantity);
-	// 각 btnCheck state를 titleBox에 공유해야 함. how?
 	const [btnCheck, setBtnCheck] = useState(true);
 
 	return (

--- a/src/store.js
+++ b/src/store.js
@@ -9,6 +9,7 @@ import logger from 'redux-logger';
 import thunk from 'redux-thunk';
 import { deliveryFeeSlice } from './store/deliveryFeeSlice';
 import { selectedItemSlice } from './store/selectedItemSlice';
+import { cartAllSelectSlice } from './store/cartAllSelectSlice';
 
 const reducers = combineReducers({
 	token: userSlice.reducer,
@@ -29,6 +30,7 @@ const store = configureStore({
 		totalCartPriceSlice: totalCartPriceSlice.reducer,
 		deliveryFeeSlice: deliveryFeeSlice.reducer,
 		selectedItemSlice: selectedItemSlice.reducer,
+		cartAllSelectSlice: cartAllSelectSlice.reducer,
 	},
 	middleware: [thunk, logger],
 });

--- a/src/store/cartAllSelectSlice.jsx
+++ b/src/store/cartAllSelectSlice.jsx
@@ -1,0 +1,16 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+// 모든 장바구니 항목 선택 state
+export const cartAllSelectSlice = createSlice({
+	name: 'cartAllSelectSlice',
+	initialState: {
+		value: true,
+	},
+	reducers: {
+		setAllSelect(state, a) {
+			state.value = a.payload;
+		},
+	},
+});
+
+export let { setAllSelect } = cartAllSelectSlice.actions;


### PR DESCRIPTION
### PR 목적
- [ ] 기능 추가 : 
- [ ] 스타일 : 
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [X] 버그 수정 : 장바구니 전체 선택 후 단일 해제 시 발생하는 금액 오류 해결
- [ ] 기타 : 


### 요약
- 원인 : 단일 선택과 전체 선택의 금액 차감 액션이 중복으로 발생하여 금액의 오류가 발생함

- 해결방법 : 
  - 전체 선택 -> 단일 해제시 해당 금액 notselectSlice에 추가 -> 이미 단일 해제에서 추가된 부분을 전체 금액에서 제외하고 갱신
  - 전체 해제 -> 단일 선택 시 해당 금액 notselectSlice에서 빠짐 -> 이미 단일 선택에서 빠진 금액은 제외하고 갱신

### 전달사항
-


### Issue Number
close : #
